### PR TITLE
Add monthly ggAVAX interest

### DIFF
--- a/dashboards/percentChange.ts
+++ b/dashboards/percentChange.ts
@@ -10,6 +10,7 @@ const metrics = {
   totalMinipoolsPercentChange:
     "sum(minipools_status_launched) + sum(minipools_status_staking) + sum(minipools_status_prelaunch) + sum(minipools_status_finished) + sum(minipools_status_withdrawable) + sum(minipools_status_cancelled) + sum(minipools_status_error)",
   effectiveGGPStakePercentChange: "effective_ggp_stake * ggp_price_in_avax",
+  ggAVAXExchange: "ggavax_avax_exchange_rate",
 };
 
 interface percentChangeMetric {
@@ -105,6 +106,13 @@ const percentChangeMetrics: percentChangeMetric[] = [
     desc: "The percent change in effective GGP stake over the last week",
     timeFrame: "week",
     query: metrics.effectiveGGPStakePercentChange,
+  },
+  {
+    name: "ggAVAXMonthlyInterestMonth",
+    title: "GG-AVAX Monthly Interest (Month)",
+    desc: "The monthly interest rate for GG-AVAX",
+    timeFrame: "month",
+    query: metrics.ggAVAXExchange,
   },
 ];
 

--- a/dashboards/percentChange.ts
+++ b/dashboards/percentChange.ts
@@ -109,8 +109,8 @@ const percentChangeMetrics: percentChangeMetric[] = [
   },
   {
     name: "ggAVAXMonthlyInterestMonth",
-    title: "GG-AVAX Monthly Interest (Month)",
-    desc: "The monthly interest rate for GG-AVAX",
+    title: "ggAVAX Monthly Interest",
+    desc: "The monthly interest rate for ggAVAX",
     timeFrame: "month",
     query: metrics.ggAVAXExchange,
   },


### PR DESCRIPTION
Here is what the new metric looks like in the ceres object.

```js
{
/// .... all other things
  ggAVAXMonthlyInterestMonth: {
    title: "GG-AVAX Monthly Interest (Month)",
    desc: "The monthly interest rate for GG-AVAX",
    name: "ggAVAXMonthlyInterestMonth",
    value: -0.39
  }
}
```

I will be updating the description, I can update the name as well if there are any objections.

To convert this to the yearly interest rate:
```js
const apy = Math.abs(ggAVAXMonthlyInterestMonth.value * 12); // as a percent. As of 18/07/2023 this is 4.68
const apy_decimal = apy / 100;
```