### PR TITLE
Change rewardsCycleSeconds to rewardsCycleStartTime

### DIFF
--- a/dashboards/rewards.ts
+++ b/dashboards/rewards.ts
@@ -31,7 +31,7 @@ const RewardsDashboard: Metrics[] = [
       args: [],
       title: "Rewards Cycle Seconds",
       desc: "The length of a rewards cycle",
-      name: "rewardsCycleSeconds",
+      name: "rewardsCycleStartTime",
       formatter: (m: Metrics, value: BigNumber): ReturnedMetric => {
         return {
           name: m.metric.name,


### PR DESCRIPTION
Getting `rewardsCycleSeconds` was returning the value for `rewardsCycleStartTime`. Turns out that we had two variables with the same name `rewardsCycleSeconds`. 

So changing the rewards start to `rewardsCycleStartTime`. 

https://multisiglabs.slack.com/archives/C04CZSVPMA7/p1693341819418799

