### PR TITLE
Cmc avax price

### DIFF
--- a/dashboards/currency.ts
+++ b/dashboards/currency.ts
@@ -1,4 +1,5 @@
 import type { Metrics, ReturnedMetric } from "../lib/types.ts";
+const apiKey = Deno.env.get("CMC_PRO_API_KEY");
 
 type AvaxPrice = {
   price: number;

--- a/dashboards/currency.ts
+++ b/dashboards/currency.ts
@@ -5,7 +5,7 @@ type AvaxPrice = {
   lastUpdated: Date;
 };
 
-const timeout = 60 * 1000; // 1 requests per minute
+const timeout = 60 * 1000 * 5; // 1 request every 5 minutes
 
 const currency: Metrics[] = [
   {
@@ -15,10 +15,7 @@ const currency: Metrics[] = [
       title: "AVAX Price",
       name: "avaxPrice",
       desc: "The price of AVAX in USD",
-      formatter: (
-        m: Metrics,
-        value: number,
-      ): ReturnedMetric => {
+      formatter: (m: Metrics, value: number): ReturnedMetric => {
         return {
           name: m.metric.name,
           title: m.metric.title,
@@ -32,13 +29,20 @@ const currency: Metrics[] = [
         const avaxPrice = await db.get<AvaxPrice>(["avaxPrice"]);
         if (
           avaxPrice?.value &&
-          (Date.now() + timeout < avaxPrice.value.lastUpdated.getTime())
+          Date.now() + timeout < avaxPrice.value.lastUpdated.getTime()
         ) {
           return avaxPrice.value.price;
         }
 
         const res = await fetch(
-          "https://api.coingecko.com/api/v3/simple/price?ids=avalanche-2&vs_currencies=usd",
+          "https://pro-api.coinmarketcap.com/v1/cryptocurrency/quotes/latest?symbol=AVAX",
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+              "X-CMC_PRO_API_KEY": apiKey,
+            },
+          },
         );
         const body = await res.json();
         const price = body["avalanche-2"].usd;


### PR DESCRIPTION
Small update to endpoint to get info from Coin Market Cap (CMC) instead of Coin Gecko (CG). The CMC response provides more granular data. 